### PR TITLE
Add statsd development server for testing changes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 REPORTER = tap
 
+start:
+	./node_modules/.bin/statsd support/statsd.config.js
+
 test:
 	@NODE_ENV=test ./node_modules/.bin/mocha \
 				--reporter $(REPORTER) \
 				--ui tdd
 
-.PHONY: test
+.PHONY: start test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "dylanmei@gmail.com",
     "url": "http://github.com/dylanmei"
   },
-  "repository" : {
+  "repository": {
     "type": "git",
     "url": "https://github.com/dylanmei/statsd-cloudwatch-backend.git"
   },
@@ -19,16 +19,22 @@
   },
   "devDependencies": {
     "chai": "~1.4.2",
-    "mocha": "*"
+    "mocha": "*",
+    "statsd": "^0.7.2"
   },
   "optionalDependencies": {},
   "scripts": {
+    "start": "make start",
     "test": "make test"
   },
   "engines": {
     "node": "*"
   },
   "keywords": [
-    "aws", "amazon", "statsd", "cloudwatch", "backend"
+    "aws",
+    "amazon",
+    "statsd",
+    "cloudwatch",
+    "backend"
   ]
 }

--- a/support/statsd.config.js
+++ b/support/statsd.config.js
@@ -1,0 +1,9 @@
+{
+  host: '0.0.0.0',
+  port: 8125,
+  backends: ['../../lib/init.js'],
+  cloudwatch: {
+    region: 'us-west-2',
+    namespace: 'statsd-cloudwatch-backend'
+  }
+}


### PR DESCRIPTION
I've been working on a few changes for Rackspace's deployment of statsd and statsd-cloudwatch-backend, and I found it helpful to include a script for starting up a local statsd server for testing changes.
